### PR TITLE
Add and remove functions

### DIFF
--- a/multicast.hpp
+++ b/multicast.hpp
@@ -82,7 +82,7 @@ public:
     multifunction& operator =(multifunction const&) = default;
     multifunction& operator =(multifunction&&) = default;
     ~multifunction() = default;
-    
+
     template <typename F>
     handle operator +=(F listener) {
         return add(listener);

--- a/multicast.hpp
+++ b/multicast.hpp
@@ -82,15 +82,24 @@ public:
     multifunction& operator =(multifunction const&) = default;
     multifunction& operator =(multifunction&&) = default;
     ~multifunction() = default;
-
+    
     template <typename F>
     handle operator +=(F listener) {
+        return add(listener);
+    }
+
+    template <typename F>
+    handle add(F listener) {
         listeners.push_back(listener);
         handle_lookup.push_back(listeners.size() - 1);
         return handle{handle_lookup.size() - 1};
     }
 
     void operator -=(handle handle) {
+        remove(handle);
+    }
+
+    void remove(handle handle) {
         auto i = handle_lookup[handle.id];
 
         if (i == NIL) return;


### PR DESCRIPTION
To help when using a multicast object stored in a pointer, I've renamed the += and -= operators to add and remove and have made the original operators call the existing implementations.